### PR TITLE
Smoll documentation fix

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -243,7 +243,7 @@ the same as `getChildren()`).
     $tree = $nsm->fetchTreeAsArray(1);
 
     foreach ($tree as $node) {
-        echo str_repeat('&nbsp;&nbsp;', $node->getLevel()) . $node->getName() . "\n";
+        echo str_repeat('&nbsp;&nbsp;', $node->getLevel()) . $node . "<br>";
     }
 
 


### PR DESCRIPTION
$node->getName() - undefined method, for call NodeName enough __toString from Node interface
